### PR TITLE
Implement support to promises for async expectations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "BSD-2-Clause",
   "devDependencies": {
     "chai": "~1.9.1",
+    "es6-promise": "^4.0.5",
     "mocha": "~1.18.2",
     "requirejs": "~2.1.11"
   },

--- a/test/index.html
+++ b/test/index.html
@@ -10,6 +10,7 @@
 <script src="../src/plugin.js"></script>
 
 <!-- dependency for amd_test -->
+<script src="../node_modules/es6-promise/dist/es6-promise.auto.js"></script>
 <script src="../node_modules/requirejs/require.js"></script>
 <script src="../test/amd_test.js"></script>
 <script src="../test/assert_test.js"></script>

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,4 @@
 var changes = require("../src/plugin.js");
 global.chai = require("chai");
+require('es6-promise').polyfill();
 chai.use(changes);


### PR DESCRIPTION
This PR adds the support for promises on the async cases.

Being so, now we can avoid doing things like this:

```javascript
expect(function(done) {
   doSomethingAsync().then(done);
}).to.alter(function(done) {
  doAnotherthingAsync().then(function(value) {
    done(null, value);
  }).catch(done);
}, {
  callback: done
});
```
we can do just:

```javascript
expect(function() {
   return doSomethingAsync();
}).to.alter(function() {
  return doAnotherthingAsync();
}, {
  callback: done
});
```

We can even just return the expectation from the test or chain it with a `then` for test runners that accepts a promise to be returned from the test instead of using a `done` callback, like Mocha. We can do this:

```javascript
return expect(function() {
   return doSomethingAsync();
}).to.alter(function() {
  return doAnotherthingAsync();
});
```

Let me know if you have some question or if I should change something.

By the way, nice plugin! I'd like to contribute more to it. :)